### PR TITLE
fix checker declaration in clang/include/clang/StaticAnalyzer/Checkers/Checkers.td

### DIFF
--- a/clang-analyzer-guide.tex
+++ b/clang-analyzer-guide.tex
@@ -300,16 +300,15 @@ All right, you got me: even putting the pointer to \lstinline|main| into a varia
 First, let us provide a definition of the checker in the list of checkers. Open up \lstinline|lib/StaticAnalyzer/Checkers/Checkers.td| in the clang source tree, and add a simple description of the checker somewhere too, say, \lstinline|alpha.core| package of checkers:
 \begin{lstlisting}[style=commandline,title=\lstinline|@Checkers.td@|]
 @@@...@@@
- HelpText<"Check for assignment of a fixed address to a pointer">,
- DescFile<"FixedAddressChecker.cpp">;
+ HelpText<"Check for assignment of a fixed address to a pointer">;
 
 @@def MainCallChecker : Checker<"MainCall">,@@
 @@ HelpText<"Check for calls to main">,@@
-@@ DescFile<"MainCallChecker.cpp">;@@
+@@ Documentation<NotDocumented>;@@
 
 def PointerArithChecker : Checker<"PointerArithm">,
  HelpText<"Check for pointer arithmetic on locations other than array elements">,
- DescFile<"PointerArithChecker">;
+ Documentation<HasDocumentation>;
 @@@...@@@
 \end{lstlisting}
 \end{nobr}


### PR DESCRIPTION
starting from Commit 35fc356fec4ae76dd9d083bf1dd708c08f453394 the DescFile was removed.
starting from Commit 2f234cbfb05549c62130bf53fc500c0c612f4f7b the Documentation was added.
fix according to those changes.